### PR TITLE
Add workaround to error in make of sgx-runtime

### DIFF
--- a/src/howto_private_tx.md
+++ b/src/howto_private_tx.md
@@ -113,18 +113,6 @@ cd ~/work/substraTEE-worker/bin
 ./substratee-worker run
 ```
 
-Note: When launching the worker from within the docker environment, the following error is currently occurring:
-```bash
-thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: SGX_ERROR_NO_DEVICE', worker/src/main.rs:180:31
-```
-To workaround this problem enter:
-```bash
-LD_LIBRARY_PATH=/opt/intel/sgx-aesm-service/aesm/ /opt/intel/sgx-aesm-service/aesm/aesm_service & 
-./substratee-worker init-shard
-```
-followed by the rest of the above mentioned commands.
-
-
 ## Play in terminal 3
 
 ```bash
@@ -154,4 +142,16 @@ ls -la
 
 # give all files back to the external user
 chown -R <NUMBER1>:<NUMBER2> substraTEE-worker substraTEE-node
+```
+
+## Troubleshooting
+
+When launching the worker from within the docker environment, the following error may occurr:
+```bash
+thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: SGX_ERROR_NO_DEVICE', worker/src/main.rs:180:31
+```
+To workaround this problem enter:
+```bash
+LD_LIBRARY_PATH=/opt/intel/sgx-aesm-service/aesm/ /opt/intel/sgx-aesm-service/aesm/aesm_service & 
+./substratee-worker init-shard
 ```

--- a/src/howto_private_tx.md
+++ b/src/howto_private_tx.md
@@ -113,7 +113,14 @@ cd ~/work/substraTEE-worker/bin
 ./substratee-worker run
 ```
 
-Note: Docker environment is currently not working. In case 
+Note: When launching the worker from within the docker environment, the following error is currently occurring:
+```bash
+thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: SGX_ERROR_NO_DEVICE', worker/src/main.rs:180:31
+```
+To workaround this problem, enter:
+```bash
+LD_LIBRARY_PATH=/opt/intel/sgx-aesm-service/aesm/ /opt/intel/sgx-aesm-service/aesm/aesm_service & 
+```
 
 ## Play in terminal 3
 

--- a/src/howto_private_tx.md
+++ b/src/howto_private_tx.md
@@ -65,6 +65,7 @@ make
 
 The rest of the setup should now work without any further errors:
 
+```bash
 # use your SPID and KEY from Intel
 echo "<YOUR SPID>" > bin/spid.txt
 echo "<YOUR KEY>" > bin/key.txt

--- a/src/howto_private_tx.md
+++ b/src/howto_private_tx.md
@@ -34,13 +34,13 @@ make
 # this might take 10min+ on a fast machine
 ```
 
-In case you encounter the error 
+In case you get the error:
 ```bash
 error: failed to get `sgx-runtime` as a dependency of package `substratee-stf v0.6.12-sub2.0.0 (/root/work/substraTEE-worker/stf)`
 Caused by:
   failed to load source for dependency `sgx-runtime`
 ```
-you need to edit the file Cargo.lock manually. Find the package inclusion of sgx-runtime, looking similiar to:
+you need to edit the file Cargo.lock manually. Within the file, find the inclusion of the package sgx-runtime. It should look similiar to:
 ```rust
 [[package]]
 name = "sgx-runtime"
@@ -54,7 +54,7 @@ and delete the last bit after (and with) the # tag of the source:
 ```rust
 source = "git+https://github.com/scs/sgx-runtime?tag=v0.6.12-sub2.0.0"
 ```
-and save your changes. If you can not save the changes due to permission denied follow the steps described in the Cleanup section below. Since the directory substraTEE-node has not yet been cloned only change the permission of substraTEE-worker. Saving should now work.
+and save your changes. If you can not save the changes due to "permission denied", follow the steps described in the Cleanup section below. Since the directory substraTEE-node has not yet been cloned only change the permission of substraTEE-worker. Saving should now work.
 
 Re-enter the substraTEE-worker directory and try to make again:
 ```bash
@@ -62,6 +62,8 @@ cd substraTEE-worker
 make
 # this might take 10min+ on a fast machine
 ```
+
+The rest of the setup should now work without any further errors:
 
 # use your SPID and KEY from Intel
 echo "<YOUR SPID>" > bin/spid.txt

--- a/src/howto_private_tx.md
+++ b/src/howto_private_tx.md
@@ -50,20 +50,20 @@ dependencies = [
 *--snip
 ]
 ```
-and delete the last bit after (and with) the # tag of the source:
+Delete the last bit after (and with) the # tag of the source:
 ```rust
 source = "git+https://github.com/scs/sgx-runtime?tag=v0.6.12-sub2.0.0"
 ```
-and save your changes. If you can not save the changes due to "permission denied", follow the steps described in the Cleanup section below. Since the directory substraTEE-node has not yet been cloned only change the permission of substraTEE-worker. Saving should now work.
+Save your changes. If you can not save the changes due to "permission denied", follow the steps described in the Cleanup section below. Since the directory substraTEE-node has not yet been cloned only change the permission of substraTEE-worker. Saving should work after the cleanup.
 
-Re-enter the substraTEE-worker directory and try to make again:
+Re-enter the substraTEE-worker directory and try to run the make command again:
 ```bash
 cd substraTEE-worker
 make
 # this might take 10min+ on a fast machine
 ```
 
-The rest of the setup should now work without any further errors:
+The rest of the setup should now work without further errors:
 
 ```bash
 # use your SPID and KEY from Intel

--- a/src/howto_private_tx.md
+++ b/src/howto_private_tx.md
@@ -117,10 +117,13 @@ Note: When launching the worker from within the docker environment, the followin
 ```bash
 thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: SGX_ERROR_NO_DEVICE', worker/src/main.rs:180:31
 ```
-To workaround this problem, enter:
+To workaround this problem enter:
 ```bash
 LD_LIBRARY_PATH=/opt/intel/sgx-aesm-service/aesm/ /opt/intel/sgx-aesm-service/aesm/aesm_service & 
+./substratee-worker init-shard
 ```
+followed by the rest of the above mentioned commands.
+
 
 ## Play in terminal 3
 

--- a/src/howto_private_tx.md
+++ b/src/howto_private_tx.md
@@ -32,6 +32,36 @@ cd substraTEE-worker
 git checkout v0.6.12-sub2.0.0
 make
 # this might take 10min+ on a fast machine
+```
+
+In case you encounter the error 
+```bash
+error: failed to get `sgx-runtime` as a dependency of package `substratee-stf v0.6.12-sub2.0.0 (/root/work/substraTEE-worker/stf)`
+Caused by:
+  failed to load source for dependency `sgx-runtime`
+```
+you need to edit the file Cargo.lock manually. Find the package inclusion of sgx-runtime, looking similiar to:
+```rust
+[[package]]
+name = "sgx-runtime"
+version = "0.6.12-sub2.0.0"
+source = "git+https://github.com/scs/sgx-runtime?tag=v0.6.12-sub2.0.0#daace7e56a250e79132962311ac0e7935faa8385"
+dependencies = [
+*--snip
+]
+```
+and delete the last bit after (and with) the # tag of the source:
+```rust
+source = "git+https://github.com/scs/sgx-runtime?tag=v0.6.12-sub2.0.0"
+```
+and save your changes. If you can not save the changes due to permission denied follow the steps described in the Cleanup section below. Since the directory substraTEE-node has not yet been cloned only change the permission of substraTEE-worker. Saving should now work.
+
+Re-enter the substraTEE-worker directory and try to make again:
+```bash
+cd substraTEE-worker
+make
+# this might take 10min+ on a fast machine
+```
 
 # use your SPID and KEY from Intel
 echo "<YOUR SPID>" > bin/spid.txt
@@ -79,6 +109,8 @@ cd ~/work/substraTEE-worker/bin
 ./substratee-worker signing-key
 ./substratee-worker run
 ```
+
+Note: Docker environment is currently not working. In case 
 
 ## Play in terminal 3
 


### PR DESCRIPTION
Workaround to error
 "error: failed to get `sgx-runtime` as a dependency of package `substratee-stf v0.6.12-sub2.0.0 (/root/work/substraTEE-worker/stf)`
Caused by:
  failed to load source for dependency `sgx-runtime"
in make command of substraTEE-worker.