### PR TITLE
Update integritee-service run parameters

### DIFF
--- a/src/howto_direct_tx.md
+++ b/src/howto_direct_tx.md
@@ -72,11 +72,8 @@ use `Ctrl-B + cursors` to move between terminals
 cd ~/work/worker/bin
 # create empty INTEL key files
 touch spid.txt key.txt
-./integritee-service init-shard
-./integritee-service shielding-key
-./integritee-service signing-key
 ./integritee-service mrenclave > ~/mrenclave.b58
-./integritee-service run --skip-ra --dev
+./integritee-service --clean-reset run --skip-ra --dev
 ```
 wait until you see blocks being synched
 

--- a/src/howto_private_tx.md
+++ b/src/howto_private_tx.md
@@ -68,11 +68,8 @@ use `Ctrl-B + cursors` to move between terminals
 cd ~/work/worker/bin
 # create empty INTEL key files
 touch spid.txt key.txt
-./integritee-service init-shard
-./integritee-service shielding-key
-./integritee-service signing-key
 ./integritee-service mrenclave > ~/mrenclave.b58
-./integritee-service run --skip-ra --dev
+./integritee-service --clean-reset run --skip-ra --dev
 ```
 
 ## Play in terminal 3

--- a/src/howto_sidechain_multivalidateer.md
+++ b/src/howto_sidechain_multivalidateer.md
@@ -60,9 +60,6 @@ Prepare the worker by generating all the necessary keys and files used for start
 cd ~/work/worker/bin
 # create empty INTEL key files
 touch spid.txt key.txt
-./integritee-service init-shard
-./integritee-service shielding-key
-./integritee-service signing-key
 ./integritee-service mrenclave > ~/mrenclave.b58
 ```
 

--- a/src/howto_worker.md
+++ b/src/howto_worker.md
@@ -144,9 +144,9 @@ cd worker
 make
 ```
 
-this might take 10min+ on a fast machine.
+This might take 10min+ on a fast machine.
 
-then you'll have to provide your SPID and KEY (see above)
+Then you'll have to provide your SPID and KEY (see above)
 
 ```bash
 echo "<YOUR SPID>" > bin/spid.txt
@@ -157,10 +157,7 @@ echo "<YOUR KEY>" > bin/key.txt
 
 ```bash
 cd bin
-./integritee-service init-shard
-./integritee-service shielding-key
-./integritee-service signing-key
-./integritee-service run --ns <yournodeip>
+./integritee-service --clean-reset run --node-url <yournodeip> --node-port <port>
 ```
 
 

--- a/src/security_tm_chainrelay.md
+++ b/src/security_tm_chainrelay.md
@@ -19,22 +19,22 @@ The following points will be analysed:
 ### User
 User of the system that holds tokens either on-chain or in an incognito account.
 
-* He uses the integritee-cli
-* He can send extrinsics/transactions to the node that will then be processed by the enclave
-* He can query his own enclave state, the enclave public key and the mutual-remote-attestation port directly from a worker over WebSocket
-* He holds his key pairs (for on-chain and incognito accounts)
+* They use the integritee-cli
+* They can send extrinsics/transactions to the node that will then be processed by the enclave
+* They can query their own enclave state, the enclave public key and the mutual-remote-attestation port directly from a worker over WebSocket
+* They hold their key pairs (for on-chain and incognito accounts)
 
 ### Worker operator
 Operates the worker and the enclave.
 
-* He uses the integritee-service
-* He has full access to the system (HW, OS and services)
+* They use the integritee-service
+* They have full access to the system (HW, OS and services)
 
 ### Vendor
 Releases Integritee software
 
-* He distributes SW binaries
-* He can sign enclaves with MRSIGNER
+* They distribute SW binaries
+* They can sign enclaves with MRSIGNER
 
 There is no specific vendor in Integritee as it is open source code that can be deterministically built by anyone to reach an identical MRENCLAVE for the enclave. Therefore, each operator is also a vendor!
 


### PR DESCRIPTION
With the changes from https://github.com/integritee-network/worker/pull/724, calling the `integritee-service` has been simplified. The book has been updated accordingly.