### PR TITLE
Add section for web-socket server scaling

### DIFF
--- a/src/howto_worker.md
+++ b/src/howto_worker.md
@@ -163,4 +163,7 @@ cd bin
 ./integritee-service run --ns <yournodeip>
 ```
 
+## Worker direct calls scalability
 
+For direct calls, a worker runs a web-socket server inside the enclave. An important factor for scalability is the transaction throughput of a single worker instance, which is in part defined by the maximum number of concurrent socket connections possible. On Linux by default, a process can have a maximum of `1024` concurrent file descriptors (show by `ulimit -n`).
+If the web-socket server hits that limit, incoming connections will be declined until one of the established connections is closed. Permanently changing the `ulimit -n` value can be done in the `/etc/security/limits.conf` configuration file. See [this](https://linuxhint.com/permanently_set_ulimit_value/) guide for more information.


### PR DESCRIPTION
Discovered while benchmarking and testing the web-socket server. Add information for the hard system limits on Linux regarding number of concurrent sockets.

Requested by @haerdib in PR https://github.com/integritee-network/worker/pull/766#discussion_r881385404 